### PR TITLE
Fix dependency issues with satellite.js

### DIFF
--- a/jspredict.js
+++ b/jspredict.js
@@ -69,7 +69,7 @@
 
   // Npm
   if (typeof require !== 'undefined') {
-    var satellite = require('satellite.js').satellite;
+    var satellite = require('satellite.js');
     m_moment = require('moment');
   }
   // Meteor


### PR DESCRIPTION
Concurrently, there are some changes to satellite.js that breaks jspredict.

In this case, `require(satellite.js).satellite` returns undefined. Changing one line fixes this issue. 