### PR TITLE
Update version and dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jspredict",
   "main": "jspredict.js",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "authors": [
     "Roshan Jobanputra <roshan@spire.com>"
   ],
@@ -32,7 +32,7 @@
     "tests"
   ],
   "dependencies": {
-    "satellite.js": "~1.2.0",
-    "moment": "~2.10.6"
+    "satellite.js": "~3.0.1",
+    "moment": "~2.24.0"
   }
 }

--- a/jspredict.js
+++ b/jspredict.js
@@ -1,11 +1,12 @@
-// jspredict v1.0.3
+// jspredict v1.1.1
 // Author: Roshan Jobanputra
 // https://github.com/nsat/jspredict
 
 // Changelog:
-// v1.0.3 (rosh93)  - If we cant approximate our aos within max_iterations, return null and dont attempt to return a bad transit object. Fix a few jslint warnings
-// v1.0.2 (jotenko)	- Added parameter 'maxTransits' to function 'transits' (allows the user to define a maximum number of transits to be calculated, for performance management)
-// v1.0.1 (nsat)		- First release
+// v1.1.1 (cantino) - Update satellite.js dependency
+// v1.0.3 (rosh93) - If we cant approximate our aos within max_iterations, return null and dont attempt to return a bad transit object. Fix a few jslint warnings
+// v1.0.2 (jotenko) - Added parameter 'maxTransits' to function 'transits' (allows the user to define a maximum number of transits to be calculated, for performance management)
+// v1.0.1 (nsat) - First release
 
 // Copyright (c) 2015, Spire Global Inc
 // All rights reserved.

--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   summary: "javascript port of predict open-source satellite tracking library",
-  version: "1.0.3",
+  version: "1.1.1",
   name: "rosh93:jspredict",
   git: "https://github.com/nsat/jspredict"
 });
 
 Package.onUse(function(api) {
-  api.use("momentjs:moment@2.10.6");
+  api.use("momentjs:moment@2.24.0");
   api.addFiles('satellite.js', ['client', 'server'], {
     bare: true
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspredict",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "description": "javascript port of predict open-source satellite tracking library",
   "main": "jspredict.js",
   "repository": {


### PR DESCRIPTION
Update the version and dependencies for jspredit. Published to npm
```
>> npm publish
npm notice
npm notice 📦  jspredict@1.1.1
npm notice === Tarball Contents ===
npm notice 1.5kB  LICENSE
npm notice 203B   export.js
npm notice 15.8kB jspredict.js
npm notice 428B   package.js
npm notice 693B   bower.json
npm notice 742B   package.json
npm notice 4.3kB  README.md
npm notice === Tarball Details ===
npm notice name:          jspredict
npm notice version:       1.1.1
npm notice package size:  7.3 kB
npm notice unpacked size: 23.6 kB
npm notice shasum:        9b2ab832065d6d4f07003950ac71183b79206790
npm notice integrity:     sha512-bAs+xp7m/Pvt7[...]B/5996ZyONRoQ==
npm notice total files:   7
npm notice
+ jspredict@1.1.1
```